### PR TITLE
Added Error property to AccountInfoResponse

### DIFF
--- a/NanoRPC/Models/Account/AccountInfo.cs
+++ b/NanoRPC/Models/Account/AccountInfo.cs
@@ -39,5 +39,6 @@ namespace NanoRPC
     public string Representative { get; set; }
     public string Weight { get; set; }
     public NanoAmount Pending { get; set; }
+    public string Error { get; set; }
   }
 }


### PR DESCRIPTION
It is possible that an account has not been used when an AccountInfoRequest is sent for that account. In that case, an "Error" field is returned by the server. This change allows that field to be populated. This is useful for detecting accounts that have not had their first block created.